### PR TITLE
Loosen base constraint to allow 4.12.*

### DIFF
--- a/accelerate-fft.cabal
+++ b/accelerate-fft.cabal
@@ -1,5 +1,5 @@
 Name:                   accelerate-fft
-Version:                1.2.0.0
+Version:                1.2.0.1
 Cabal-version:          >= 1.8
 Tested-with:            GHC >= 7.10
 Build-type:             Simple
@@ -43,7 +43,7 @@ flag llvm-cpu
 
 library
   build-depends:
-        base                    >= 4.7  && < 4.12
+        base                    >= 4.7  && < 4.13
       , accelerate              >= 1.2  && < 1.3
       , bytestring              >= 0.9
       , lens-accelerate         >= 0.2


### PR DESCRIPTION
This change allows for builds with GHC 8.6.