### PR TITLE
Improve FFT*Many_plans functions

### DIFF
--- a/src/Data/Array/Accelerate/Math/FFT/LLVM/PTX.hs
+++ b/src/Data/Array/Accelerate/Math/FFT/LLVM/PTX.hs
@@ -164,13 +164,13 @@ fft3D_plans
 fft2DMany_plans :: Plans (DIM2, FFT.Type)
 fft2DMany_plans
   = unsafePerformIO
-  $ createPlan (\(Z:.h:.w, t) -> FFT.planMany [h,w] Nothing Nothing t 1)
+  $ createPlan (\(Z:.h:.w, t) -> FFT.planMany [w] Nothing Nothing t h)
                (\(Z:.h:.w, t) -> fromEnum t `hashWithSalt` h `hashWithSalt` w)
 
 {-# NOINLINE fft3DMany_plans #-}
 fft3DMany_plans :: Plans (DIM3, FFT.Type)
 fft3DMany_plans
   = unsafePerformIO
-  $ createPlan (\(Z:.d:.h:.w, t) -> FFT.planMany [d,h,w] Nothing Nothing t 1)
+  $ createPlan (\(Z:.d:.h:.w, t) -> FFT.planMany [w] Nothing Nothing t (d*h))
                (\(Z:.d:.h:.w, t) -> fromEnum t `hashWithSalt` d `hashWithSalt` h `hashWithSalt` w)
 


### PR DESCRIPTION
FFT2Many_plans created a plan for usual 2D FFT
  (that is why fft and fft2D return the same results
   with PTX backend and different results with Native backend).
The same problem with FFT3Many_plans function.

I've changed the "layout" to a list with single Int (length of the innermost dimension)
and the "batched" to a number of 1D FFTs (h in case of a 2D array and d*h in case of a 3D array)

Now, 1D FFTs over 2- and 3-dimensional arrays are performed correctly.